### PR TITLE
retirando chamada para arquivo inexistente no functions.php issue-18

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,11 +19,6 @@ if ( ! isset( $content_width ) ) {
 	$content_width = 600;
 }
 
-/**
- * Horizon Theme Widgets.
- */
-require_once get_template_directory() . '/core/classes/widgets/class-widget-like-box.php';
-
 if ( ! function_exists( 'horizon_theme_setup_features' ) ) {
 
 	/**


### PR DESCRIPTION
Conforme relatado na issue-18 existia um `require_once` no functions.php que chamava um arquivo inexistente e isso gera um erro na ativação do tema. Esse PR faz a correção deste problema, apagando a linha com o erro.
