### PR TITLE
corrigindo classes na div de imagem do joker-sep

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ get_header(); ?>
 		<section class="joker-sep">
 			<div class="container-fluid">
 				<div class="row">
-					<div class="col-md-6 col-xs-4 no-padding left hidden-xs">
+					<div class="col-md-6 col-sm-4 no-padding left hidden-xs">
 						<img src="<?php echo get_stylesheet_directory_uri(); ?>/assets/images/img-joker.jpg" alt="">
 					</div>
 					<div class="col-md-6 col-sm-8 col-xs-12 no-padding right">


### PR DESCRIPTION
Acho que incluiram col-xs-4 por engano, deveria ser col-sm-4 visto que temos hidden-xs no final e que a outra div usa col-sm-8.
