### PR TITLE
Removing unused boostrap modules 

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -23,45 +23,45 @@ Domain Path: languages/
 @import "bootstrap/normalize";
 
 // Dependencies
-@import "bootstrap/glyphicons";
+//@import "bootstrap/glyphicons";
 
 // Core CSS
 @import "bootstrap/scaffolding";
 @import "bootstrap/type";
-@import "bootstrap/code";
+//@import "bootstrap/code";
 @import "bootstrap/grid";
-@import "bootstrap/tables";
+//@import "bootstrap/tables";
 @import "bootstrap/forms";
-@import "bootstrap/buttons";
+//@import "bootstrap/buttons";
 
 // Components
 @import "bootstrap/component-animations";
 @import "bootstrap/dropdowns";
-@import "bootstrap/button-groups";
-@import "bootstrap/input-groups";
+//@import "bootstrap/button-groups";
+//@import "bootstrap/input-groups";
 @import "bootstrap/navs";
 @import "bootstrap/navbar";
-@import "bootstrap/breadcrumbs";
-@import "bootstrap/pagination";
-@import "bootstrap/pager";
-@import "bootstrap/labels";
-@import "bootstrap/badges";
-@import "bootstrap/jumbotron";
-@import "bootstrap/thumbnails";
-@import "bootstrap/alerts";
-@import "bootstrap/progress-bars";
-@import "bootstrap/media";
-@import "bootstrap/list-group";
-@import "bootstrap/panels";
+//@import "bootstrap/breadcrumbs";
+//@import "bootstrap/pagination";
+//@import "bootstrap/pager";
+//@import "bootstrap/labels";
+//@import "bootstrap/badges";
+//@import "bootstrap/jumbotron";
+//@import "bootstrap/thumbnails";
+//@import "bootstrap/alerts";
+//@import "bootstrap/progress-bars";
+//@import "bootstrap/media";
+//@import "bootstrap/list-group";
+//@import "bootstrap/panels";
 @import "bootstrap/responsive-embed";
-@import "bootstrap/wells";
-@import "bootstrap/close";
+//@import "bootstrap/wells";
+//@import "bootstrap/close";
 
 // Components w/ JavaScript
-@import "bootstrap/modals";
-@import "bootstrap/tooltip";
-@import "bootstrap/popovers";
-@import "bootstrap/carousel";
+//@import "bootstrap/modals";
+//@import "bootstrap/tooltip";
+//@import "bootstrap/popovers";
+//@import "bootstrap/carousel";
 
 // Utility classes
 @import "bootstrap/utilities";


### PR DESCRIPTION
Segue uma sugestão para remoção de alguns módulos do bootstrap, a folha de estilos reduziu de 157k para 67k (não comprimido), caso no futuro precisemos de algum componente, basta adicionar.

Sei que estão discutindo sobre usar ou não bootstrap em #30 , mas se estamos usando sass porquê não utilizá-lo para remover os componentes que não estamos utilizando?

Não querendo colocar lenha na fogueira, mas acho que precisamos definir e superar esse ponto para podemos prosseguir com o desenvolvimento.

No aguardo para discussões. Não irei fazer o merge desse pull request e vou deixar a seguinte sugestão: Fazer o merge desse pull request encerra a discussão, recusar esse pull request indica que nós iremos refazer o CSS do zero.
