### PR TITLE
ativando plugin automaticamente via gerenciador de dependencias TGM

### DIFF
--- a/inc/register_plugins.php
+++ b/inc/register_plugins.php
@@ -28,6 +28,7 @@ function horizon_theme_register_required_plugins() {
 			'required' 				=> false,
 			'version' 				=> '3.5.3',
 			'force_activation' 		=> false,
+			'is_automatic'			=> true,
 		),
 		array(
 			'name'     				=> 'Homepage Control',
@@ -35,6 +36,7 @@ function horizon_theme_register_required_plugins() {
 			'required' 				=> false,
 			'version' 				=> '2.0.1',
 			'force_activation' 		=> false,
+			'is_automatic'			=> true,
 		),
 
 	);


### PR DESCRIPTION
Incluindo o parâmetro `'is_automatic' => true,` no array que define os plugins que devem ser sugeridos instalar. Esse parâmetro faz com que o plugin seja ativado pelo usuário quando ele aceita instalar as dependências.
